### PR TITLE
APIセットアップ及び接続テストの実施

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,3 +78,6 @@ gem "rails-i18n", "~> 7.0"
 gem "devise-i18n"
 
 gem "devise"
+
+gem "openai"
+gem "dotenv-rails", groups: [:development, :test]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,6 +118,10 @@ GEM
       devise (>= 4.9.0)
       rails-i18n
     diff-lcs (1.6.2)
+    dotenv (3.1.8)
+    dotenv-rails (3.1.8)
+      dotenv (= 3.1.8)
+      railties (>= 6.1)
     drb (2.2.3)
     erb (6.0.0)
     erubi (1.13.1)
@@ -177,6 +181,8 @@ GEM
       racc (~> 1.4)
     nokogiri (1.18.10-x86_64-linux-gnu)
       racc (~> 1.4)
+    openai (0.36.1)
+      connection_pool
     orm_adapter (0.5.0)
     parallel (1.27.0)
     parser (3.3.10.0)
@@ -352,9 +358,11 @@ DEPENDENCIES
   debug
   devise
   devise-i18n
+  dotenv-rails
   factory_bot_rails
   importmap-rails
   jbuilder
+  openai
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.1.6)

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ MVPリリース時点では個人で写真+メッセージからストーリー�
 データベース：PostgreSQL
 デプロイ先：Render
 ユーザー認証機能：Devise
-AIストーリー生成機能：OpenAI API(gpt-4o)
+AIストーリー生成機能：OpenAI API(gpt-5o mini)
 ストレージ管理機能：ActiveStorage
 外部ストレージサービス：AWS S3
 

--- a/config/initializers/openai.rb
+++ b/config/initializers/openai.rb
@@ -1,0 +1,5 @@
+require "openai"
+
+OPENAI_CLIENT = OpenAI::Client.new(
+  api_key: ENV.fetch("OPENAI_API_KEY")
+)


### PR DESCRIPTION
Closes #38 

OpenAI API（gpt-5-mini）を利用するための設定を追加しました。
.env に API Key を設定し、config/initializers/openai.rb でクライアント初期化を行っています。
Rails コンソール上で正常に動作すること確認済みです。

OPENAI_API_KEY を .env および Render（本番環境）に登録
Rails コンソールで動作確認用スクリプトを実行　→ 正常に動作すること確認ずみ
Chat Completion 取得方法を、最新の SDK 仕様に合わせて修正

