### PR TITLE
投稿詳細からストーリー生成と表示機能を実装

### DIFF
--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -1,0 +1,23 @@
+class StoriesController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_post
+
+  def create
+    service = StoryGenerationService.new(user: current_user, post: @post)
+    story = service.call
+
+    if story.present?
+      flash[:notice] = "ストーリーを生成しました。"
+    else
+      flash[:alert] = "ストーリーの生成に失敗しました。時間をおいて再度お試しください。"
+    end
+
+    redirect_to post_path(@post)
+  end
+
+  private
+
+  def set_post
+    @post = current_user.posts.find(params[:post_id])
+  end
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -2,6 +2,7 @@ class Post < ApplicationRecord
   belongs_to :user
 
   has_many :photos, dependent: :destroy
+  has_many :stories, dependent: :destroy
   has_many :ai_generations, dependent: :destroy
   has_one :story, dependent: :destroy
 

--- a/app/services/story_generation_service.rb
+++ b/app/services/story_generation_service.rb
@@ -19,7 +19,7 @@ class StoryGenerationService
       model: MODEL_NAME,
       messages: [
         {
-          role: :system,
+          role: :system, 
           content: "あなたは家族や友人との思い出を、あたたかい日本語の物語に仕立てるストーリーテラーです。"
         },
         {

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,16 +1,48 @@
 <h2>投稿詳細</h2>
 
+<p>
+  <strong>メッセージ</strong><br>
+  <%= @post.message %>
+</p>
+
+<p>
+  <strong>思い出の日付</strong><br>
+  <%= @post.posted_on %>
+</p>
+
 <% if @post.image_url.present? %>
   <p>
-    <img src="<%= @post.image_url %>" alt="投稿画像" style="max-width: 400px;">
+    <strong>画像</strong><br>
+    <img src="<%= @post.image_url %>" alt="投稿画像" style="max-width: 300px;">
   </p>
 <% end %>
 
-<p><strong>メッセージ</strong></p>
-<p><%= simple_format(@post.message) %></p>
+<hr>
 
-<p><strong>思い出の日付</strong></p>
-<p><%= @post.posted_on&.strftime("%Y-%m-%d") %></p>
+<%= button_to "この投稿からストーリーを生成する",
+              post_stories_path(@post),
+              method: :post,
+              data: { turbo: false },
+              class: "btn btn-primary" %>
+
+<hr>
+
+<h3>生成されたストーリー</h3>
+
+<% if @post.stories.any? %>
+  <% @post.stories.order(created_at: :desc).each do |story| %>
+    <div class="story-block">
+      <h4><%= story.title %></h4>
+      <p><%= simple_format(story.body) %></p>
+      <p class="meta">
+        生成日: <%= story.generated_on || story.created_at.to_date %>
+      </p>
+      <hr>
+    </div>
+  <% end %>
+<% else %>
+  <p>まだストーリーは生成されていません。</p>
+<% end %>
 
 <%= link_to "投稿一覧に戻る", posts_path %>
 <%= link_to "新規投稿", new_post_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,4 +14,7 @@ Rails.application.routes.draw do
   root "homes#index"
 
   resources :posts, only: %i[index new create show]
+  resources :posts do
+    resources :stories, only: [:create]
+  end
 end


### PR DESCRIPTION
Closes #40 
Closes #41 

投稿詳細画面からAIを活用したストーリーを生成出来るようにしました。
生成されたストーリーを `stories` テーブルに保存し、投稿詳細画面で表示できるようにしました。